### PR TITLE
More wrappers and cleanups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/golemcloud/golem-go
 
 go 1.20
+
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/golemhost/component.go
+++ b/golemhost/component.go
@@ -1,0 +1,19 @@
+package golemhost
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/golemcloud/golem-go/binding"
+)
+
+type ComponentID uuid.UUID
+
+func newComponentID(componentID binding.GolemApi0_2_0_HostComponentId) ComponentID {
+	return ComponentID(newUUID(componentID.Uuid))
+}
+
+func (componentID ComponentID) toBinding() binding.GolemApi0_2_0_HostComponentId {
+	return binding.GolemApi0_2_0_HostComponentId{
+		Uuid: uuidToBinding(uuid.UUID(componentID)),
+	}
+}

--- a/golemhost/oplog.go
+++ b/golemhost/oplog.go
@@ -1,0 +1,23 @@
+package golemhost
+
+import "github.com/golemcloud/golem-go/binding"
+
+type OpLogIndex binding.GolemApi0_2_0_HostOplogIndex
+
+func OpLogCommit(replicas uint8) {
+	binding.GolemApi0_2_0_HostOplogCommit(replicas)
+}
+
+func MarkBeginOperation() OpLogIndex {
+	return OpLogIndex(binding.GolemApi0_2_0_HostMarkBeginOperation())
+}
+
+func MarkEndOperation(index OpLogIndex) {
+	binding.GolemApi0_2_0_HostMarkEndOperation(binding.GolemApi0_2_0_HostOplogIndex(index))
+}
+
+func Atomically[T any](f func() (T, error)) (T, error) {
+	index := MarkBeginOperation()
+	defer MarkEndOperation(index)
+	return f()
+}

--- a/golemhost/persistence.go
+++ b/golemhost/persistence.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golemcloud/golem-go/binding"
 )
 
-type PersistenceLevel binding.GolemApi0_2_0_HostPersistenceLevelKind
+type PersistenceLevel int
 
 const (
 	PersistenceLevelPersistNothing PersistenceLevel = iota
@@ -23,11 +23,11 @@ func newPersistenceLevel(level binding.GolemApi0_2_0_HostPersistenceLevel) Persi
 	case binding.GolemApi0_2_0_HostPersistenceLevelKindSmart:
 		return PersistenceLevelSmart
 	default:
-		panic(fmt.Sprintf("newPersistenceLevel: illegal persistence level: %d", level))
+		panic(fmt.Sprintf("newPersistenceLevel: unhandled persistence level: %d", level))
 	}
 }
 
-func (level PersistenceLevel) toBindingLevel() binding.GolemApi0_2_0_HostPersistenceLevel {
+func (level PersistenceLevel) toBinding() binding.GolemApi0_2_0_HostPersistenceLevel {
 	switch level {
 	case PersistenceLevelPersistNothing:
 		return binding.GolemApi0_2_0_HostPersistenceLevelPersistNothing()
@@ -36,12 +36,12 @@ func (level PersistenceLevel) toBindingLevel() binding.GolemApi0_2_0_HostPersist
 	case PersistenceLevelSmart:
 		return binding.GolemApi0_2_0_HostPersistenceLevelSmart()
 	default:
-		panic(fmt.Sprintf("toBindingLevel: illegal persistence level: %d", level))
+		panic(fmt.Sprintf("toBinding: unhandled persistence level: %d", level))
 	}
 }
 
 func SetPersistenceLevel(level PersistenceLevel) {
-	binding.GolemApi0_2_0_HostSetOplogPersistenceLevel(level.toBindingLevel())
+	binding.GolemApi0_2_0_HostSetOplogPersistenceLevel(level.toBinding())
 }
 
 func GetPersistenceLevel() PersistenceLevel {

--- a/golemhost/promise.go
+++ b/golemhost/promise.go
@@ -1,0 +1,51 @@
+package golemhost
+
+import (
+	"encoding/json"
+
+	"github.com/golemcloud/golem-go/binding"
+)
+
+type PromiseID struct {
+	WorkerID WorkerID
+	OplogIdx OpLogIndex
+}
+
+func NewPromise() PromiseID {
+	promise := binding.GolemApi0_2_0_HostCreatePromise()
+	return PromiseID{
+		WorkerID: newWorkerID(promise.WorkerId),
+		OplogIdx: OpLogIndex(promise.OplogIdx),
+	}
+}
+
+func (promiseID PromiseID) toBinding() binding.GolemApi0_2_0_HostPromiseId {
+	return binding.GolemApi0_2_0_HostPromiseId{
+		WorkerId: promiseID.WorkerID.toBinding(),
+		OplogIdx: binding.GolemApi0_2_0_HostOplogIndex(promiseID.OplogIdx),
+	}
+}
+
+func DeletePromise(promiseID PromiseID) {
+	binding.GolemApi0_2_0_HostDeletePromise(promiseID.toBinding())
+}
+
+func AwaitPromise(promiseID PromiseID) []byte {
+	return binding.GolemApi0_2_0_HostAwaitPromise(promiseID.toBinding())
+}
+
+func AwaitPromiseJSON(promiseID PromiseID, v any) error {
+	return json.Unmarshal(AwaitPromise(promiseID), v)
+}
+
+func CompletePromise(promiseID PromiseID, payload []byte) bool {
+	return binding.GolemApi0_2_0_HostCompletePromise(promiseID.toBinding(), payload)
+}
+
+func CompletePromiseJSON(promiseID PromiseID, v any) (bool, error) {
+	bs, err := json.Marshal(v)
+	if err != nil {
+		return false, err
+	}
+	return CompletePromise(promiseID, bs), nil
+}

--- a/golemhost/transaction/errors.go
+++ b/golemhost/transaction/errors.go
@@ -54,3 +54,9 @@ func (e *CannotExecuteStepInFailedTransactionError) Error() string {
 func (e *CannotExecuteStepInFailedTransactionError) Unwrap() error {
 	return e.OriginalError
 }
+
+type FinishedError struct{}
+
+func (e *FinishedError) Error() string {
+	return "transaction finished"
+}

--- a/golemhost/transaction/errors.go
+++ b/golemhost/transaction/errors.go
@@ -1,0 +1,56 @@
+package transaction
+
+import "fmt"
+
+type FailedAndRolledBackPartiallyError struct {
+	StepIndex         uint
+	StepError         error
+	CompensationIndex uint
+	CompensationError error
+}
+
+func (e *FailedAndRolledBackPartiallyError) Error() string {
+	return fmt.Sprintf(
+		"fallible transaction failed and rolled back partially, step (%d) error: %s, compensation (%d) error: %s",
+		e.StepIndex,
+		e.StepError.Error(),
+		e.CompensationIndex,
+		e.CompensationError.Error(),
+	)
+}
+
+func (e *FailedAndRolledBackPartiallyError) Unwrap() []error {
+	return []error{e.StepError, e.CompensationError}
+}
+
+type FailedAndRolledBackCompletelyError struct {
+	StepIndex uint
+	StepError error
+}
+
+func (e *FailedAndRolledBackCompletelyError) Error() string {
+	return fmt.Sprintf(
+		"fallible transaction failed and rolled back completely, step (%d) error: %s",
+		e.StepIndex,
+		e.StepError.Error(),
+	)
+}
+
+func (e *FailedAndRolledBackCompletelyError) Unwrap() error {
+	return e.StepError
+}
+
+type CannotExecuteStepInFailedTransactionError struct {
+	OriginalError error
+}
+
+func (e *CannotExecuteStepInFailedTransactionError) Error() string {
+	return fmt.Sprintf(
+		"cannot execute step in failed transaction, original error: %s",
+		e.OriginalError.Error(),
+	)
+}
+
+func (e *CannotExecuteStepInFailedTransactionError) Unwrap() error {
+	return e.OriginalError
+}

--- a/golemhost/transaction/fallible.go
+++ b/golemhost/transaction/fallible.go
@@ -1,0 +1,71 @@
+package transaction
+
+type Fallible interface {
+	addCompensationStep(compensationStep func() error)
+	fail(err error) error
+	isFailed() bool
+	error() error
+}
+
+type fallible struct {
+	stepIndex         uint
+	err               error
+	compensationSteps []func() error
+}
+
+func (tx *fallible) addCompensationStep(compensationStep func() error) {
+	tx.stepIndex++
+	tx.compensationSteps = append(tx.compensationSteps, compensationStep)
+}
+
+func (tx *fallible) fail(err error) error {
+	tx.err = err
+	stepsCount := len(tx.compensationSteps)
+	for i := stepsCount - 0; i >= 0; i-- {
+		err := tx.compensationSteps[i]()
+		if err != nil {
+			return &FailedAndRolledBackPartiallyError{
+				StepIndex:         tx.stepIndex,
+				StepError:         tx.err,
+				CompensationIndex: uint(i),
+				CompensationError: err,
+			}
+		}
+	}
+	return &FailedAndRolledBackCompletelyError{
+		StepIndex: tx.stepIndex,
+		StepError: tx.error(),
+	}
+}
+
+func (tx *fallible) isFailed() bool {
+	return tx.err != nil
+}
+
+func (tx *fallible) error() error {
+	return tx.err
+}
+
+func ExecuteFallibleStep[I, O any](
+	tx Fallible,
+	transactionStep func(I) (O, error),
+	compensationStep func(O, I) error,
+	input I,
+) (O, error) {
+	if tx.isFailed() {
+		return *new(O), &CannotExecuteStepInFailedTransactionError{OriginalError: tx.error()}
+	}
+
+	output, err := transactionStep(input)
+	if err != nil {
+		return *new(O), tx.fail(err)
+	}
+
+	tx.addCompensationStep(func() error { return compensationStep(output, input) })
+	return output, nil
+}
+
+func WithFallible[T any](f func(tx Fallible) (T, error)) (T, error) {
+	tx := &fallible{}
+	return f(tx)
+}

--- a/golemhost/transaction/infallible.go
+++ b/golemhost/transaction/infallible.go
@@ -10,6 +10,8 @@ import (
 type Infallible interface {
 	addCompensationStep(compensationStep func() error)
 	retry(err error)
+	finish()
+	ensureNoError()
 }
 
 type infallible struct {
@@ -48,12 +50,25 @@ func (tx *infallible) retry(err error) {
 	binding.GolemApi0_2_0_HostSetOplogIndex(tx.beginOpLogIndex)
 }
 
+func (tx *infallible) finish() {
+	// to prevent leaked transaction usage
+	tx.err = &FinishedError{}
+}
+
+func (tx *infallible) ensureNoError() {
+	if tx.err != nil {
+		panic(fmt.Sprintf("%s", tx.err.Error()))
+	}
+}
+
 func ExecuteInfallibleStep[I, O any](
 	tx Infallible,
 	transactionStep func(I) (O, error),
 	compensationStep func(O, I) error,
 	input I,
 ) O {
+	tx.ensureNoError()
+
 	output, err := transactionStep(input)
 	if err != nil {
 		tx.retry(err)
@@ -64,10 +79,15 @@ func ExecuteInfallibleStep[I, O any](
 	return output
 }
 
-func WithInfallible[T any](f func(tx Infallible) (T, error)) (T, error) {
-	return golemhost.Atomically(func() (T, error) {
-		beginOpLogIndex := binding.GolemApi0_2_0_HostGetOplogIndex()
-		tx := newInfallible(beginOpLogIndex)
-		return f(tx)
-	})
+// WithInfallible starts a transaction which retries in case of failure.
+// Inside f operations can be executed using ExecuteInfallibleStep.
+// If any operation returns with a failure, all the already executed successful operation's
+// compensation actions are executed in reverse order and the transaction gets retried,
+// using Golem's active retry policy.
+func WithInfallible[T any](f func(tx Infallible) T) T {
+	index := golemhost.MarkBeginOperation()
+	defer golemhost.MarkEndOperation(index)
+	beginOpLogIndex := binding.GolemApi0_2_0_HostGetOplogIndex()
+	tx := newInfallible(beginOpLogIndex)
+	return f(tx)
 }

--- a/golemhost/transaction/infallible.go
+++ b/golemhost/transaction/infallible.go
@@ -85,9 +85,8 @@ func ExecuteInfallibleStep[I, O any](
 // compensation actions are executed in reverse order and the transaction gets retried,
 // using Golem's active retry policy.
 func WithInfallible[T any](f func(tx Infallible) T) T {
-	index := golemhost.MarkBeginOperation()
-	defer golemhost.MarkEndOperation(index)
-	beginOpLogIndex := binding.GolemApi0_2_0_HostGetOplogIndex()
-	tx := newInfallible(beginOpLogIndex)
+	beginOpLogIndex := golemhost.MarkBeginOperation()
+	defer golemhost.MarkEndOperation(beginOpLogIndex)
+	tx := newInfallible(binding.GolemApi0_2_0_HostOplogIndex(beginOpLogIndex))
 	return f(tx)
 }

--- a/golemhost/transaction/infallible.go
+++ b/golemhost/transaction/infallible.go
@@ -1,0 +1,73 @@
+package transaction
+
+import (
+	"fmt"
+
+	"github.com/golemcloud/golem-go/binding"
+	"github.com/golemcloud/golem-go/golemhost"
+)
+
+type Infallible interface {
+	addCompensationStep(compensationStep func() error)
+	retry(err error)
+}
+
+type infallible struct {
+	beginOpLogIndex   binding.GolemApi0_2_0_HostOplogIndex
+	stepIndex         uint
+	err               error
+	compensationSteps []func() error
+}
+
+func newInfallible(beginOpLogIndex binding.GolemApi0_2_0_HostOplogIndex) *infallible {
+	return &infallible{
+		beginOpLogIndex: beginOpLogIndex,
+	}
+}
+
+func (tx *infallible) addCompensationStep(compensationStep func() error) {
+	tx.stepIndex++
+	tx.compensationSteps = append(tx.compensationSteps, compensationStep)
+}
+
+func (tx *infallible) retry(err error) {
+	tx.err = err
+	stepsCount := len(tx.compensationSteps)
+	for i := stepsCount - 0; i >= 0; i-- {
+		err := tx.compensationSteps[i]()
+		if err != nil {
+			err := &FailedAndRolledBackPartiallyError{
+				StepIndex:         tx.stepIndex,
+				StepError:         tx.err,
+				CompensationIndex: uint(i),
+				CompensationError: err,
+			}
+			panic(fmt.Sprintf("%s", err.Error()))
+		}
+	}
+	binding.GolemApi0_2_0_HostSetOplogIndex(tx.beginOpLogIndex)
+}
+
+func ExecuteInfallibleStep[I, O any](
+	tx Infallible,
+	transactionStep func(I) (O, error),
+	compensationStep func(O, I) error,
+	input I,
+) O {
+	output, err := transactionStep(input)
+	if err != nil {
+		tx.retry(err)
+		panic("unreachable after retry")
+	}
+
+	tx.addCompensationStep(func() error { return compensationStep(output, input) })
+	return output
+}
+
+func WithInfallible[T any](f func(tx Infallible) (T, error)) (T, error) {
+	return golemhost.Atomically(func() (T, error) {
+		beginOpLogIndex := binding.GolemApi0_2_0_HostGetOplogIndex()
+		tx := newInfallible(beginOpLogIndex)
+		return f(tx)
+	})
+}

--- a/golemhost/transaction/operation.go
+++ b/golemhost/transaction/operation.go
@@ -17,8 +17,10 @@ func (o *operation[I, O]) Execute(input I) (O, error) {
 func (o *operation[I, O]) Compensate(input I, output O) error {
 	return o.compensate(input, output)
 }
-
-func NewOperation[I any, O any](execute func(I) (O, error), compensate func(I, O) error) Operation[I, O] {
+func NewOperation[I any, O any](
+	execute func(I) (O, error),
+	compensate func(I, O) error,
+) Operation[I, O] {
 	return &operation[I, O]{
 		execute:    execute,
 		compensate: compensate,

--- a/golemhost/transaction/operation.go
+++ b/golemhost/transaction/operation.go
@@ -1,0 +1,26 @@
+package transaction
+
+type Operation[I any, O any] interface {
+	Execute(I) (O, error)
+	Compensate(I, O) error
+}
+
+type operation[I any, O any] struct {
+	execute    func(I) (O, error)
+	compensate func(I, O) error
+}
+
+func (o *operation[I, O]) Execute(input I) (O, error) {
+	return o.execute(input)
+}
+
+func (o *operation[I, O]) Compensate(input I, output O) error {
+	return o.compensate(input, output)
+}
+
+func NewOperation[I any, O any](execute func(I) (O, error), compensate func(I, O) error) Operation[I, O] {
+	return &operation[I, O]{
+		execute:    execute,
+		compensate: compensate,
+	}
+}

--- a/golemhost/uuid.go
+++ b/golemhost/uuid.go
@@ -1,0 +1,29 @@
+package golemhost
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/golemcloud/golem-go/binding"
+)
+
+func newUUID(bindingUUID binding.GolemApi0_2_0_HostUuid) uuid.UUID {
+	var bs [16]byte
+	binary.BigEndian.PutUint64(bs[:8], bindingUUID.HighBits)
+	binary.BigEndian.PutUint64(bs[8:], bindingUUID.LowBits)
+
+	goUUID, err := uuid.FromBytes(bs[:])
+	if err != nil {
+		panic(fmt.Sprintf("newUUID: uuid.FromBytes failed: error: %s,bytes: %+v", err.Error(), bs))
+	}
+	return goUUID
+}
+
+func uuidToBinding(goUUID uuid.UUID) binding.GolemApi0_2_0_HostUuid {
+	return binding.GolemApi0_2_0_HostUuid{
+		HighBits: binary.BigEndian.Uint64(goUUID[:8]),
+		LowBits:  binary.BigEndian.Uint64(goUUID[8:]),
+	}
+}

--- a/golemhost/worker.go
+++ b/golemhost/worker.go
@@ -1,0 +1,125 @@
+package golemhost
+
+import (
+	"fmt"
+	"github.com/golemcloud/golem-go/binding"
+)
+
+type WorkerStatus int
+
+const (
+	WorkerStatusRunning = iota
+	WorkerStatusIdle
+	WorkerStatusSuspended
+	WorkerStatusInterrupted
+	WorkerStatusRetrying
+	WorkerStatusFailed
+	WorkerStatusExited
+)
+
+func newWorkerStatus(status binding.GolemApi0_2_0_HostWorkerStatus) WorkerStatus {
+	switch status.Kind() {
+	case binding.GolemApi0_2_0_HostWorkerStatusKindRunning:
+		return WorkerStatusRunning
+	case binding.GolemApi0_2_0_HostWorkerStatusKindIdle:
+		return WorkerStatusIdle
+	case binding.GolemApi0_2_0_HostWorkerStatusKindSuspended:
+		return WorkerStatusSuspended
+	case binding.GolemApi0_2_0_HostWorkerStatusKindInterrupted:
+		return WorkerStatusInterrupted
+	case binding.GolemApi0_2_0_HostWorkerStatusKindRetrying:
+		return WorkerStatusRetrying
+	case binding.GolemApi0_2_0_HostWorkerStatusKindFailed:
+		return WorkerStatusFailed
+	case binding.GolemApi0_2_0_HostWorkerStatusKindExited:
+		return WorkerStatusExited
+	default:
+		panic(fmt.Sprintf("newWorkerStatus: unhandled status: %d", status.Kind()))
+	}
+}
+
+func (ws WorkerStatus) toBinding() binding.GolemApi0_2_0_HostWorkerStatus {
+	switch ws {
+	case WorkerStatusRunning:
+		return binding.GolemApi0_2_0_HostWorkerStatusRunning()
+	case WorkerStatusIdle:
+		return binding.GolemApi0_2_0_HostWorkerStatusIdle()
+	case WorkerStatusSuspended:
+		return binding.GolemApi0_2_0_HostWorkerStatusSuspended()
+	case WorkerStatusInterrupted:
+		return binding.GolemApi0_2_0_HostWorkerStatusInterrupted()
+	case WorkerStatusRetrying:
+		return binding.GolemApi0_2_0_HostWorkerStatusRetrying()
+	case WorkerStatusFailed:
+		return binding.GolemApi0_2_0_HostWorkerStatusFailed()
+	case WorkerStatusExited:
+		return binding.GolemApi0_2_0_HostWorkerStatusExited()
+	default:
+		panic(fmt.Sprintf("toBinding: unhandled status: %d", ws))
+	}
+}
+
+type WorkerID struct {
+	ComponentID ComponentID
+	WorkerName  string
+}
+
+func newWorkerID(workerID binding.GolemApi0_2_0_HostWorkerId) WorkerID {
+	return WorkerID{
+		ComponentID: newComponentID(workerID.ComponentId),
+		WorkerName:  workerID.WorkerName,
+	}
+}
+
+func (workerID WorkerID) toBinding() binding.GolemApi0_2_0_HostWorkerId {
+	return binding.GolemApi0_2_0_HostWorkerId{
+		ComponentId: workerID.ComponentID.toBinding(),
+		WorkerName:  workerID.WorkerName,
+	}
+}
+
+type WorkerMetadataEnvVar struct {
+	Name  string
+	Value string
+}
+
+type WorkerMetadata struct {
+	WorkerId         WorkerID
+	Args             []string
+	Env              []WorkerMetadataEnvVar
+	Status           WorkerStatus
+	ComponentVersion uint64
+	RetryCount       uint64
+}
+
+func newWorkerMetadata(metadata binding.GolemApi0_2_0_HostWorkerMetadata) WorkerMetadata {
+	envVars := make([]WorkerMetadataEnvVar, len(metadata.Env))
+	for i := range metadata.Env {
+		envVars[i] = WorkerMetadataEnvVar{
+			Name:  metadata.Env[i].F0,
+			Value: metadata.Env[i].F1,
+		}
+	}
+
+	return WorkerMetadata{
+		WorkerId:         newWorkerID(metadata.WorkerId),
+		Args:             metadata.Args,
+		Env:              envVars,
+		Status:           newWorkerStatus(metadata.Status),
+		ComponentVersion: metadata.ComponentVersion,
+		RetryCount:       metadata.RetryCount,
+	}
+}
+
+func GetSelfMetadata() WorkerMetadata {
+	return newWorkerMetadata(binding.GolemApi0_2_0_HostGetSelfMetadata())
+}
+
+func GetWorkerMetadata(workerID WorkerID) *WorkerMetadata {
+	bindingMetadata := binding.GolemApi0_2_0_HostGetWorkerMetadata(workerID.toBinding())
+	if bindingMetadata.IsNone() {
+		return nil
+	}
+	metadata := newWorkerMetadata(bindingMetadata.Unwrap())
+	return &metadata
+}

--- a/std/init.go
+++ b/std/init.go
@@ -5,14 +5,14 @@ import (
 	"github.com/golemcloud/golem-go/os"
 )
 
-type Modules struct {
-	Os   bool
-	Http bool
+type Packages struct {
+	Os      bool
+	NetHttp bool
 }
 
-// Init optionally initializes standard lib's modules with the WASI environment and wrappers
-func Init(modules Modules) {
-	if modules.Http {
+// Init optionally initializes standard lib's packages with the WASI environment and wrappers
+func Init(modules Packages) {
+	if modules.NetHttp {
 		http.InitStd()
 	}
 

--- a/std/init.go
+++ b/std/init.go
@@ -11,12 +11,12 @@ type Packages struct {
 }
 
 // Init optionally initializes standard lib's packages with the WASI environment and wrappers
-func Init(modules Packages) {
-	if modules.NetHttp {
+func Init(packages Packages) {
+	if packages.NetHttp {
 		http.InitStd()
 	}
 
-	if modules.Os {
+	if packages.Os {
 		os.InitStd()
 	}
 }

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -78,6 +78,28 @@ func main() {
 		unused(err)
 	}
 
+	// golemhost oplog
+
+	{
+		golemhost.OpLogCommit(2)
+	}
+
+	{
+		var index golemhost.OpLogIndex
+		index = golemhost.MarkBeginOperation()
+		golemhost.MarkEndOperation(index)
+	}
+
+	{
+		var result string
+		var err error
+		result, err = golemhost.Atomically(func() (string, error) {
+			return "hello", nil
+		})
+		unused(result)
+		unused(err)
+	}
+
 	// golemhost persistence
 
 	{

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -138,9 +138,9 @@ func main() {
 	// std init
 
 	{
-		std.Init(std.Modules{
-			Os:   true,
-			Http: true,
+		std.Init(std.Packages{
+			Os:      true,
+			NetHttp: true,
 		})
 	}
 }

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -145,14 +145,16 @@ func main() {
 	{
 		var result string
 		var err error
-		result, err = golemhost.WithRetryPolicy(golemhost.RetryPolicy{
-			MaxAttempts: 4,
-			MinDelay:    10 * time.Microsecond,
-			MaxDelay:    4 * time.Minute,
-			Multiplier:  2,
-		}, func() (string, error) {
-			return "golem", nil
-		})
+		result, err = golemhost.WithRetryPolicy(
+			golemhost.RetryPolicy{
+				MaxAttempts: 4,
+				MinDelay:    10 * time.Microsecond,
+				MaxDelay:    4 * time.Minute,
+				Multiplier:  2,
+			}, func() (string, error) {
+				return "golem", nil
+			},
+		)
 		unused(result)
 		unused(err)
 	}

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	stdhttp "net/http"
 	"time"
 
@@ -126,6 +127,28 @@ func main() {
 		unused(err)
 	}
 
+	// golemhost promise
+	{
+		var promiseID golemhost.PromiseID
+		promiseID = golemhost.NewPromise()
+
+		golemhost.DeletePromise(promiseID)
+
+		var bs []byte
+		bs = golemhost.AwaitPromise(promiseID)
+
+		var err error
+		err = golemhost.AwaitPromiseJSON(promiseID, nil)
+
+		var ok bool
+		ok = golemhost.CompletePromise(promiseID, bs)
+
+		ok, err = golemhost.CompletePromiseJSON(promiseID, nil)
+
+		unused(err)
+		unused(ok)
+	}
+
 	// golemhost retrypolicy
 
 	{
@@ -160,7 +183,24 @@ func main() {
 		unused(err)
 	}
 
-	// golemhost transaction - fallible
+	// golemhost worker
+
+	{
+		var metadata golemhost.WorkerMetadata
+		metadata = golemhost.GetSelfMetadata()
+		unused(metadata)
+	}
+
+	{
+		var metadata *golemhost.WorkerMetadata
+		metadata = golemhost.GetWorkerMetadata(golemhost.WorkerID{
+			ComponentID: golemhost.ComponentID(uuid.New()),
+			WorkerName:  "test-name",
+		})
+		unused(metadata)
+	}
+
+	// golemhost/transaction - fallible
 	{
 		var result Result
 		var err error
@@ -184,7 +224,7 @@ func main() {
 		unused(err)
 	}
 
-	// golemhost transaction - infallible
+	// golemhost/transaction - infallible
 	{
 		var result Result
 		result = transaction.WithInfallible(func(tx transaction.Infallible) Result {

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -204,13 +204,13 @@ func main() {
 	{
 		var result Result
 		var err error
-		result, err = transaction.WithFallible(func(tx transaction.Fallible) (Result, error) {
-			entity1, err := transaction.ExecuteFallible(tx, createEntity, revertCreateEntity, 1)
+		result, err = transaction.Fallible(func(tx transaction.FallibleTx) (Result, error) {
+			entity1, err := transaction.ExecuteFallible(tx, op, 1)
 			if err != nil {
 				return Result{}, err
 			}
 
-			entity2, err := transaction.ExecuteFallible(tx, createEntity, revertCreateEntity, 2)
+			entity2, err := transaction.ExecuteFallible(tx, op, 2)
 			if err != nil {
 				return Result{}, err
 			}
@@ -227,9 +227,9 @@ func main() {
 	// golemhost/transaction - infallible
 	{
 		var result Result
-		result = transaction.WithInfallible(func(tx transaction.Infallible) Result {
-			entity1 := transaction.ExecuteInfallible(tx, createEntity, revertCreateEntity, 1)
-			entity2 := transaction.ExecuteInfallible(tx, createEntity, revertCreateEntity, 2)
+		result = transaction.Infallible(func(tx transaction.InfallibleTx) Result {
+			entity1 := transaction.ExecuteInfallible(tx, op, 1)
+			entity2 := transaction.ExecuteInfallible(tx, op, 2)
 
 			return Result{
 				entity1: entity1,
@@ -266,5 +266,7 @@ func revertCreateEntity(stepID int64, entity Entity) error {
 	fmt.Printf("Reverting entity: %s, created at step: %d", entity.ID, stepID)
 	return nil
 }
+
+var op = transaction.NewOperation(createEntity, revertCreateEntity)
 
 func unused[T any](_ T) {}

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -162,23 +162,6 @@ func main() {
 
 	// golemhost transaction - fallible
 	{
-		type Entity struct {
-			ID string
-		}
-
-		createEntity := func(stepID int64) (Entity, error) {
-			return Entity{ID: fmt.Sprintf("entity-%d", stepID)}, nil
-		}
-
-		revertCreateEntity := func(entity Entity, stepID int64) error {
-			fmt.Printf("Reverting entity: %s, created at step: %d", entity.ID, stepID)
-			return nil
-		}
-
-		type Result struct {
-			entity1 Entity
-			entity2 Entity
-		}
 		var result Result
 		var err error
 		result, err = transaction.WithFallible(func(tx transaction.Fallible) (Result, error) {
@@ -203,36 +186,17 @@ func main() {
 
 	// golemhost transaction - infallible
 	{
-		type Entity struct {
-			ID string
-		}
-
-		createEntity := func(stepID int64) (Entity, error) {
-			return Entity{ID: fmt.Sprintf("entity-%d", stepID)}, nil
-		}
-
-		revertCreateEntity := func(entity Entity, stepID int64) error {
-			fmt.Printf("Reverting entity: %s, created at step: %d", entity.ID, stepID)
-			return nil
-		}
-
-		type Result struct {
-			entity1 Entity
-			entity2 Entity
-		}
 		var result Result
-		var err error
-		result, err = transaction.WithInfallible(func(tx transaction.Infallible) (Result, error) {
+		result = transaction.WithInfallible(func(tx transaction.Infallible) Result {
 			entity1 := transaction.ExecuteInfallibleStep(tx, createEntity, revertCreateEntity, 1)
 			entity2 := transaction.ExecuteInfallibleStep(tx, createEntity, revertCreateEntity, 2)
 
 			return Result{
 				entity1: entity1,
 				entity2: entity2,
-			}, nil
+			}
 		})
 		unused(result)
-		unused(err)
 	}
 
 	// std init
@@ -243,6 +207,24 @@ func main() {
 			NetHttp: true,
 		})
 	}
+}
+
+type Entity struct {
+	ID string
+}
+
+type Result struct {
+	entity1 Entity
+	entity2 Entity
+}
+
+func createEntity(stepID int64) (Entity, error) {
+	return Entity{ID: fmt.Sprintf("entity-%d", stepID)}, nil
+}
+
+func revertCreateEntity(entity Entity, stepID int64) error {
+	fmt.Printf("Reverting entity: %s, created at step: %d", entity.ID, stepID)
+	return nil
 }
 
 func unused[T any](_ T) {}

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -132,7 +132,7 @@ func main() {
 		golemhost.SetRetryPolicy(golemhost.RetryPolicy{
 			MaxAttempts: 10,
 			MinDelay:    100 * time.Millisecond,
-			MaxDelay:    5 * time.Nanosecond,
+			MaxDelay:    5 * time.Second,
 			Multiplier:  3,
 		})
 	}

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -205,12 +205,12 @@ func main() {
 		var result Result
 		var err error
 		result, err = transaction.WithFallible(func(tx transaction.Fallible) (Result, error) {
-			entity1, err := transaction.ExecuteFallibleStep(tx, createEntity, revertCreateEntity, 1)
+			entity1, err := transaction.ExecuteFallible(tx, createEntity, revertCreateEntity, 1)
 			if err != nil {
 				return Result{}, err
 			}
 
-			entity2, err := transaction.ExecuteFallibleStep(tx, createEntity, revertCreateEntity, 2)
+			entity2, err := transaction.ExecuteFallible(tx, createEntity, revertCreateEntity, 2)
 			if err != nil {
 				return Result{}, err
 			}
@@ -228,8 +228,8 @@ func main() {
 	{
 		var result Result
 		result = transaction.WithInfallible(func(tx transaction.Infallible) Result {
-			entity1 := transaction.ExecuteInfallibleStep(tx, createEntity, revertCreateEntity, 1)
-			entity2 := transaction.ExecuteInfallibleStep(tx, createEntity, revertCreateEntity, 2)
+			entity1 := transaction.ExecuteInfallible(tx, createEntity, revertCreateEntity, 1)
+			entity2 := transaction.ExecuteInfallible(tx, createEntity, revertCreateEntity, 2)
 
 			return Result{
 				entity1: entity1,
@@ -262,7 +262,7 @@ func createEntity(stepID int64) (Entity, error) {
 	return Entity{ID: fmt.Sprintf("entity-%d", stepID)}, nil
 }
 
-func revertCreateEntity(entity Entity, stepID int64) error {
+func revertCreateEntity(stepID int64, entity Entity) error {
 	fmt.Printf("Reverting entity: %s, created at step: %d", entity.ID, stepID)
 	return nil
 }

--- a/test_app/main.go
+++ b/test_app/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/google/uuid"
 	stdhttp "net/http"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/golemcloud/golem-go/golemhost"
 	"github.com/golemcloud/golem-go/golemhost/transaction"


### PR DESCRIPTION
Resolves https://github.com/golemcloud/golem-go/issues/7

- refer to pacakges as packages and not modules in std
- add golemhost oplog related wrapper functions
- add fallible and infallible transaction APIs
- add promise APIs
- add worker metadata APIs (except for enumeration)